### PR TITLE
navbar: remove class `dark`

### DIFF
--- a/.changeset/flat-hounds-kneel.md
+++ b/.changeset/flat-hounds-kneel.md
@@ -1,0 +1,5 @@
+---
+"@ivao/atmosphere-react": patch
+---
+
+navbar: remove default class `dark`

--- a/components/react/src/components/molecules/navbar/index.tsx
+++ b/components/react/src/components/molecules/navbar/index.tsx
@@ -13,7 +13,7 @@ export const Navbar: ComponentType<PropsWithChildren<NavbarProps>> = ({
   children,
 }) => {
   return (
-    <NavbarContainer className="dark">
+    <NavbarContainer>
       <div className={'flex items-center gap-3'}>
         <div className="block md:hidden">
           <IVAOLogo color={'white'} onlyIcon />


### PR DESCRIPTION
The class causes issues with items inside the navbar. I cannot see a real purpose, therefore I suggest to remove it.