### PR TITLE
Fix/navigation menu

### DIFF
--- a/.changeset/itchy-cougars-sniff.md
+++ b/.changeset/itchy-cougars-sniff.md
@@ -1,0 +1,5 @@
+---
+"@ivao/atmosphere-react": minor
+---
+
+Fixed navigation menu colors

--- a/components/react/README.md
+++ b/components/react/README.md
@@ -75,6 +75,7 @@ This command creates a `.tgz` file on the root of the `/components/react` folder
 3. To use it on your repo, add this line to your `package.json`. Replace the `.tgz` file name.
 
 ```json
-"@ivao/atmosphere-react": "file:../atmosphere/components/react/ivao-atmosphere-react-0.1.0-next.2.tgz",
+// Remember to change the version <FILE_NAME> to the file that was created
+"@ivao/atmosphere-react": "file:../atmosphere/components/react/<FILE_NAME>",
 
 ```

--- a/components/react/src/components/atoms/navigation-menu/NavigationMenuListItem.tsx
+++ b/components/react/src/components/atoms/navigation-menu/NavigationMenuListItem.tsx
@@ -16,7 +16,7 @@ export const NavigationMenuListItem = forwardRef<
       <NavigationMenuLink
         ref={ref}
         className={cn(
-          'block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground',
+          'block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent/20 hover:text-fuselage-800 focus:bg-accent focus:text-accent-foreground dark:hover:text-fuselage-50',
           className,
         )}
         {...props}

--- a/components/react/src/components/atoms/navigation-menu/navigationMenuTriggerStyle.ts
+++ b/components/react/src/components/atoms/navigation-menu/navigationMenuTriggerStyle.ts
@@ -1,5 +1,5 @@
 import { cva } from 'class-variance-authority';
 
 export const navigationMenuTriggerStyle = cva(
-  'group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50',
+  'group inline-flex h-10 w-max items-center justify-center rounded-md bg-background bg-transparent px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50',
 );

--- a/components/react/src/components/atoms/navigation-menu/navigationMenuTriggerStyle.ts
+++ b/components/react/src/components/atoms/navigation-menu/navigationMenuTriggerStyle.ts
@@ -1,5 +1,5 @@
 import { cva } from 'class-variance-authority';
 
 export const navigationMenuTriggerStyle = cva(
-  'group inline-flex h-10 w-max items-center justify-center rounded-md bg-background bg-transparent px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50',
+  'group inline-flex h-10 w-max items-center justify-center rounded-md bg-background bg-transparent px-4 py-2 text-sm font-medium transition-colors hover:bg-accent/20 hover:text-accent-foreground hover:text-fuselage-800 focus:bg-accent/20 focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-accent/20 data-[active]:text-fuselage-800 dark:hover:text-fuselage-50',
 );

--- a/components/react/src/components/molecules/navigation-menu/index.tsx
+++ b/components/react/src/components/molecules/navigation-menu/index.tsx
@@ -64,7 +64,7 @@ export const NavigationMenu: ComponentType<NavigationMenuProps> = ({
               <>
                 <NavigationMenuTrigger>{section.title}</NavigationMenuTrigger>
                 <NavigationMenuContent>
-                  <ul className="grid list-none gap-3 bg-red-600 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
+                  <ul className="grid list-none gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
                     {section.links.map((link) => (
                       <NavigationMenuListItem
                         key={link.title}

--- a/components/react/src/components/molecules/navigation-menu/index.tsx
+++ b/components/react/src/components/molecules/navigation-menu/index.tsx
@@ -64,7 +64,7 @@ export const NavigationMenu: ComponentType<NavigationMenuProps> = ({
               <>
                 <NavigationMenuTrigger>{section.title}</NavigationMenuTrigger>
                 <NavigationMenuContent>
-                  <ul className="grid list-none gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
+                  <ul className="grid list-none gap-3 bg-fuselage-100/20 p-4 backdrop-blur dark:bg-accent/20 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
                     {section.links.map((link) => (
                       <NavigationMenuListItem
                         key={link.title}

--- a/components/react/src/stories/components/NavigationMenu.stories.tsx
+++ b/components/react/src/stories/components/NavigationMenu.stories.tsx
@@ -28,7 +28,7 @@ const NavLinkComponent = forwardRef<
       console.log('clicked a link');
       onClick?.(event);
     }}
-    className={cn(className, 'text-destructive')}
+    className={cn(className, '')}
     {...props}
   />
 ));
@@ -131,9 +131,9 @@ export const Default = {
   parameters: {
     docs: {
       story: {
-        inline: false,
-        iframeHeight: 400,
+        iframeHeight: 800,
       },
     },
   },
+  decorators: [(story) => <div className="h-96 w-full">{story()}</div>],
 } satisfies Story;


### PR DESCRIPTION
- Fixed the colors on the Navigation menu
- Improved contrast.
- Improved the instruction on how to use the package on another local repo

Before:
<img width="491" height="256" alt="image" src="https://github.com/user-attachments/assets/cea42018-e5d9-4b54-838e-ea2221efb20d" />

After:
<img width="487" height="255" alt="image" src="https://github.com/user-attachments/assets/7809bd5c-9d32-4409-a73f-5dc36206914c" />
<img width="441" height="255" alt="image" src="https://github.com/user-attachments/assets/50ef8ff1-9af7-4f3d-b55c-b14a3f9781b5" />

Used in a real menu:
<img width="519" height="175" alt="image" src="https://github.com/user-attachments/assets/0f9fe556-d9d8-4f06-9f01-79c5e11ee49e" />
