### PR TITLE
style(error-boundary): dark mode

### DIFF
--- a/.changeset/cold-fans-poke.md
+++ b/.changeset/cold-fans-poke.md
@@ -1,0 +1,5 @@
+---
+"@ivao/atmosphere-react": minor
+---
+
+Added dark mode support for ErrorBoundary

--- a/components/react/src/components/atoms/error-boundary/ErrorBoundary.tsx
+++ b/components/react/src/components/atoms/error-boundary/ErrorBoundary.tsx
@@ -18,19 +18,21 @@ export const ErrorBoundaryComponent: React.FC<ErrorBoundaryProps> = ({
   };
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 bg-gradient-to-b from-fuselage-50 to-fuselage-100 p-6 text-center">
-      <div className="flex w-full max-w-md flex-col items-center space-y-6 rounded-2xl bg-white p-8 shadow-md">
-        <AlertTriangle className="h-14 w-14 text-red-500" />
-        <h1 className="text-2xl font-semibold text-gray-800">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-fuselage-50 to-fuselage-100 p-6 text-center transition-colors duration-300 dark:from-fuselage-800 dark:to-fuselage-900">
+      <div className="flex w-full max-w-md flex-col items-center space-y-6 rounded-2xl bg-white p-8 shadow-md transition-colors duration-300 dark:border dark:border-fuselage-700 dark:bg-fuselage-800">
+        <AlertTriangle className="h-14 w-14 text-red-500 dark:text-semantic-red-400" />
+
+        <h1 className="text-2xl font-semibold text-gray-800 dark:text-fuselage-50">
           Something went wrong
         </h1>
-        <p className="text-sm text-gray-600 sm:text-base">
+
+        <p className="text-sm text-gray-600 dark:text-fuselage-300 sm:text-base">
           An unexpected error occurred. You can try reloading the page or
           clearing your cookies and cache.
         </p>
 
         {debugMode && error && (
-          <pre className="max-h-64 w-full overflow-auto rounded-lg bg-gray-100 p-4 text-left text-xs text-red-600 sm:text-sm">
+          <pre className="max-h-64 w-full overflow-auto rounded-lg bg-gray-100 p-4 text-left text-xs text-red-600 dark:border dark:border-fuselage-600 dark:bg-fuselage-700 dark:text-semantic-red-200 sm:text-sm">
             {error.message || String(error)}
           </pre>
         )}
@@ -39,7 +41,7 @@ export const ErrorBoundaryComponent: React.FC<ErrorBoundaryProps> = ({
           <Button
             onClick={handleReload}
             className="flex w-auto items-center justify-center gap-2 sm:w-full"
-            size={'lg'}
+            size="lg"
           >
             <RefreshCw className="h-4 w-4" />
             Reload


### PR DESCRIPTION
- Added dark mode support

Before:
<img width="809" height="595" alt="image" src="https://github.com/user-attachments/assets/bcb48f44-b002-405c-8b20-86f33a4f7abc" />

After:
<img width="799" height="573" alt="image" src="https://github.com/user-attachments/assets/007fe302-0396-4cc3-8b56-5b7559ca1c7a" />
