### PR TITLE
fix(sidebar): remove button to close on mobile

### DIFF
--- a/.changeset/two-pianos-fly.md
+++ b/.changeset/two-pianos-fly.md
@@ -1,0 +1,5 @@
+---
+"@ivao/atmosphere-react": minor
+---
+
+Make sidebar mobile responsive

--- a/components/react/src/components/atoms/sidebar/SidebarContainer.tsx
+++ b/components/react/src/components/atoms/sidebar/SidebarContainer.tsx
@@ -14,7 +14,9 @@ export const SidebarContainer: ComponentType<PropsWithChildren> = ({
       <div className="flex flex-col items-start gap-4 px-4 py-5">
         {children}
       </div>
-      <SidebarCollapseButton />
+      <div className="hidden md:block">
+        <SidebarCollapseButton />
+      </div>
     </aside>
   );
 };

--- a/components/react/src/components/atoms/sidebar/SidebarItem.tsx
+++ b/components/react/src/components/atoms/sidebar/SidebarItem.tsx
@@ -63,7 +63,7 @@ export const SidebarItem = ({
         className={cn(
           'flex shrink-0 flex-col items-start whitespace-nowrap transition-all',
           isSidebarOpen
-            ? `ml-4 ${props.isGroupOpen ? 'w-fit' : 'w-48'} opacity-100`
+            ? `ml-4 w-fit min-w-48 opacity-100`
             : 'invisible w-0 opacity-0',
         )}
       >


### PR DESCRIPTION
We don't want to collapse the sidebar on mobile because it wouldn't be UX friendly.
Mobile looking sidebar:

<img width="383" height="778" alt="image" src="https://github.com/user-attachments/assets/3f1b0bde-9b03-43af-83cd-4da3f3a77b9d" />

