### PR TITLE
fix(sidebar): add overflow-y-auto to scrollable content area

### DIFF
--- a/.changeset/few-impalas-greet.md
+++ b/.changeset/few-impalas-greet.md
@@ -1,0 +1,11 @@
+---
+"@ivao/atmosphere-react": patch
+---
+
+**fix(sidebar): add overflow-y-auto to scrollable content area**
+
+**WHAT:** Added `overflow-y-auto` to the inner scrollable container in `SidebarContainer`.
+
+**WHY:** When the sidebar contained more items than the viewport height, content was clipped and users could not access lower items. There was no scroll handling.
+
+**HOW:** No consumer action required. Sidebars will now scroll automatically when content exceeds the available height.

--- a/components/react/src/components/atoms/sidebar/SidebarContainer.tsx
+++ b/components/react/src/components/atoms/sidebar/SidebarContainer.tsx
@@ -11,7 +11,7 @@ export const SidebarContainer: ComponentType<PropsWithChildren> = ({
         'flex h-full flex-col justify-between border-r border-fuselage-200 bg-fuselage-50 dark:border-fuselage-700 dark:bg-fuselage-900'
       }
     >
-      <div className="flex flex-col items-start gap-4 px-4 py-5">
+      <div className="flex flex-col items-start gap-4 overflow-y-auto px-4 py-5">
         {children}
       </div>
       <SidebarCollapseButton />


### PR DESCRIPTION
Closes #121

## Summary

- Adds overflow-y-auto to the scrollable inner div in SidebarContainer
- Introduces itest + @testing-library/react + jsdom testing infrastructure
- Adds SidebarContainer unit test verifying the overflow class is present

## Changes

| File | Change |
|------|--------|
| components/react/src/components/atoms/sidebar/SidebarContainer.tsx | Added overflow-y-auto to the flex column container |
| components/react/src/components/atoms/sidebar/SidebarContainer.test.tsx | New test verifying scrollable area has overflow class |
| components/react/vitest.config.ts | New Vitest config with jsdom + tsconfig paths |
| components/react/src/test-setup.ts | New setup file importing jest-dom matchers |
| components/react/package.json | Added 	est script + vitest/testing-library devDeps |
| pnpm-lock.yaml | Lockfile updated with new dev dependencies |

## Test Plan

- [x] pnpm test --run passes (1/1 SidebarContainer tests)
- [x] pnpm lint passes on modified files

## Type

- [x] Bug fix (	ype:bug)