### PR TITLE
fix(select): forward id to trigger instead of leaking to SelectRoot

### DIFF
--- a/.changeset/loud-bats-jump.md
+++ b/.changeset/loud-bats-jump.md
@@ -1,0 +1,11 @@
+---
+"@ivao/atmosphere-react": patch
+---
+
+**fix(select): forward id to trigger instead of leaking to SelectRoot**
+
+**WHAT:** Destructures `id` from `SelectProps` and forwards it to `SelectTrigger` instead of spreading it into `SelectRoot`.
+
+**WHY:** DOM attributes like `id` were incorrectly passed to Radix UI's `SelectRoot`, which does not support them. This caused React warnings and prevented consumers from properly labeling or testing the select component.
+
+**HOW:** No consumer action required. Passing `id` to `<Select />` now correctly places it on the trigger element.

--- a/.changeset/loud-bats-jump.md
+++ b/.changeset/loud-bats-jump.md
@@ -2,4 +2,4 @@
 "@ivao/atmosphere-react": patch
 ---
 
-select: forward id to trigger instead of leaking to SelectRoot
+select: forward id to SelectTrigger instead of leaking to SelectRoot

--- a/.changeset/loud-bats-jump.md
+++ b/.changeset/loud-bats-jump.md
@@ -2,10 +2,4 @@
 "@ivao/atmosphere-react": patch
 ---
 
-**fix(select): forward id to trigger instead of leaking to SelectRoot**
-
-**WHAT:** Destructures `id` from `SelectProps` and forwards it to `SelectTrigger` instead of spreading it into `SelectRoot`.
-
-**WHY:** DOM attributes like `id` were incorrectly passed to Radix UI's `SelectRoot`, which does not support them. This caused React warnings and prevented consumers from properly labeling or testing the select component.
-
-**HOW:** No consumer action required. Passing `id` to `<Select />` now correctly places it on the trigger element.
+select: forward id to trigger instead of leaking to SelectRoot

--- a/components/react/src/components/molecules/select/index.tsx
+++ b/components/react/src/components/molecules/select/index.tsx
@@ -48,11 +48,12 @@ export const Select: ComponentType<SelectProps> = ({
   className,
   items,
   placeholder = 'Select an option',
+  id,
   ...props
 }: SelectProps) => {
   return (
     <SelectRoot {...props}>
-      <SelectTrigger className={className}>
+      <SelectTrigger className={className} id={id}>
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectPortal>


### PR DESCRIPTION
Closes #107

## Summary

- Destructures id from SelectProps before spreading to SelectRoot
- Forwards id to SelectTrigger so it appears on the visible combobox element
- Prevents unsupported DOM attributes from leaking into Radix SelectRoot

## Changes

| File | Change |
|------|--------|
| components/react/src/components/molecules/select/index.tsx | Extract id from props, pass to SelectTrigger |
| components/react/src/components/molecules/select/index.test.tsx | New test verifying id is on trigger, not root |

## Test Plan

- [x] pnpm test --run passes (2/2 Select tests)
- [x] pnpm lint passes on modified files

## Type

- [x] Bug fix (	ype:bug)