### PR TITLE
feat(data-table): apply meta.className to table cells

### DIFF
--- a/.changeset/bright-wolves-sing.md
+++ b/.changeset/bright-wolves-sing.md
@@ -1,0 +1,21 @@
+---
+"@ivao/atmosphere-react": minor
+---
+
+**feat(data-table): apply meta.className to table cells**
+
+**WHAT:** `DataTable` now reads `meta.className` from column definitions and applies it to each `TableCell`.
+
+**WHY:** Consumers needed a way to style individual table cells (e.g., text alignment, colors) without custom cell renderers for every column.
+
+**HOW:** Add `meta: { className: 'your-class' }` to any column definition:
+
+```tsx
+const columns = [
+  {
+    accessorKey: 'amount',
+    header: 'Amount',
+    meta: { className: 'text-right font-mono' },
+  },
+];
+```

--- a/components/react/src/components/molecules/data-table/DataTable.tsx
+++ b/components/react/src/components/molecules/data-table/DataTable.tsx
@@ -112,10 +112,7 @@ export const DataTable = <TData,>({
                   {row.getVisibleCells().map((cell) => (
                     <TableCell
                       key={cell.id}
-                      className={
-                        (cell.column.columnDef.meta as { className?: string })
-                          ?.className
-                      }
+                      className={cell.column.columnDef.meta?.className}
                     >
                       {flexRender(
                         cell.column.columnDef.cell,

--- a/components/react/src/components/molecules/data-table/DataTable.tsx
+++ b/components/react/src/components/molecules/data-table/DataTable.tsx
@@ -110,7 +110,13 @@ export const DataTable = <TData,>({
                   data-state={row.getIsSelected() && 'selected'}
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
+                    <TableCell
+                      key={cell.id}
+                      className={
+                        (cell.column.columnDef.meta as { className?: string })
+                          ?.className
+                      }
+                    >
                       {flexRender(
                         cell.column.columnDef.cell,
                         cell.getContext(),

--- a/components/react/src/tanstack-table.d.ts
+++ b/components/react/src/tanstack-table.d.ts
@@ -1,0 +1,8 @@
+import '@tanstack/react-table';
+
+declare module '@tanstack/react-table' {
+  interface ColumnMeta<TData extends RowData, TValue> {
+    name?: string;
+    className?: string;
+  }
+}


### PR DESCRIPTION
Closes #129

## Summary

- Reads `meta.className` from `column.columnDef.meta` in `DataTable`
- Applies the className to each `TableCell` during row rendering
- Falls back to no extra classes when `meta.className` is absent

## Changes

| File | Change |
|------|--------|
| `components/react/src/components/molecules/data-table/DataTable.tsx` | Pass `meta.className` to `<TableCell>` |

## Test Plan

- [x] `pnpm lint` passes on modified files
- [x] Component renders correctly in Storybook

## Type

- [x] New feature (`type:feature`)
