### PR TITLE
feat(data-table): use meta.name instead of column.id in view options

### DIFF
--- a/.changeset/happy-foxes-dance.md
+++ b/.changeset/happy-foxes-dance.md
@@ -1,0 +1,23 @@
+---
+"@ivao/atmosphere-react": minor
+---
+
+**feat(data-table): use meta.name instead of column.id in view options**
+
+**WHAT:** `DataTableViewOptions` now reads `meta.name` from column definitions to display human-readable labels in the "Toggle columns" dropdown.
+
+**WHY:** The dropdown previously showed raw column IDs like `firstName` or `createdAt`, which are not user-friendly. Consumers needed a way to provide custom display names.
+
+**HOW:** Add `meta: { name: 'Your Label' }` to any column definition:
+
+```tsx
+const columns = [
+  {
+    accessorKey: 'firstName',
+    header: 'First Name',
+    meta: { name: 'First Name' },
+  },
+];
+```
+
+When `meta.name` is absent, the component falls back to `column.id` for backward compatibility.

--- a/components/react/src/components/molecules/data-table/DataTableViewOptions.tsx
+++ b/components/react/src/components/molecules/data-table/DataTableViewOptions.tsx
@@ -54,8 +54,7 @@ export function DataTableViewOptions<TData>({
               checked={column.getIsVisible()}
               onCheckedChange={(value) => column.toggleVisibility(!!value)}
             >
-              {(column.columnDef.meta as { name?: string } | undefined)?.name ??
-                column.id}
+              {column.columnDef.meta?.name ?? column.id}
             </DropdownMenuCheckboxItem>
           );
         })}

--- a/components/react/src/components/molecules/data-table/DataTableViewOptions.tsx
+++ b/components/react/src/components/molecules/data-table/DataTableViewOptions.tsx
@@ -54,7 +54,8 @@ export function DataTableViewOptions<TData>({
               checked={column.getIsVisible()}
               onCheckedChange={(value) => column.toggleVisibility(!!value)}
             >
-              {column.id}
+              {(column.columnDef.meta as { name?: string } | undefined)?.name ??
+                column.id}
             </DropdownMenuCheckboxItem>
           );
         })}

--- a/components/react/src/tanstack-table.d.ts
+++ b/components/react/src/tanstack-table.d.ts
@@ -1,0 +1,7 @@
+import '@tanstack/react-table';
+
+declare module '@tanstack/react-table' {
+  interface ColumnMeta<TData extends RowData, TValue> {
+    name?: string;
+  }
+}


### PR DESCRIPTION
Closes #130

## Summary

- Reads `meta.name` from `column.columnDef.meta` in `DataTableViewOptions`
- Displays custom human-readable names in the "Toggle columns" dropdown
- Falls back to `column.id` when `meta.name` is not provided (backward compatible)

## Changes

| File | Change |
|------|--------|
| `components/react/src/components/molecules/data-table/DataTableViewOptions.tsx` | Use `meta.name ?? column.id` for dropdown labels |

## Test Plan

- [x] `pnpm lint` passes on modified files
- [x] Component renders correctly in Storybook

## Type

- [x] New feature (`type:feature`)
