### PR TITLE
Fix default variant background styling for dark mode

### DIFF
--- a/.changeset/mighty-candies-yell.md
+++ b/.changeset/mighty-candies-yell.md
@@ -1,0 +1,6 @@
+---
+"@ivao/atmosphere-react": patch
+---
+
+alert: no background for non-default variants
+  

--- a/components/react/src/components/atoms/alert/alertVariants.ts
+++ b/components/react/src/components/atoms/alert/alertVariants.ts
@@ -8,9 +8,9 @@ export const alertVariants = cva(
         default:
           'border-fuselage-300 bg-background text-foreground dark:border-fuselage-600 dark:[&>h5]:text-fuselage-50',
         success:
-          'text-semantic-green-700 dark:text-semantic-green-300 dark:[&>h5]:text-semantic-green-500 [&>svg]:text-semantic-green-500 border-green-600 dark:border-green-500',
+          'text-semantic-green-700 dark:text-semantic-green-300 dark:[&>h5]:text-semantic-green-500 [&>svg]:text-semantic-green-500 border-green-600 bg-green-50 dark:border-green-500 dark:bg-green-950',
         destructive:
-          'border-destructive text-semantic-red-600 dark:border-destructive dark:text-destructive-foreground dark:[&>h5]:text-destructive [&>svg]:text-destructive',
+          'border-destructive text-semantic-red-600 dark:border-destructive dark:text-destructive-foreground dark:[&>h5]:text-destructive [&>svg]:text-destructive bg-red-50 dark:bg-red-950',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Changes
- Updated the default variant in `alertVariants.ts` to remove `bg-background` from light mode
- Kept `dark:bg-background` for dark mode to maintain visibility

## Before
Alert had a filled background in both light and dark modes.

## After
Alert has no background in light mode, but retains the background fill in dark mode.