### PR TITLE
Refactor Navbar components to simplify prop types

### DIFF
--- a/components/react/src/components/atoms/navbar/index.tsx
+++ b/components/react/src/components/atoms/navbar/index.tsx
@@ -1,17 +1,17 @@
-import { ComponentType, DetailedHTMLProps, HTMLAttributes } from 'react';
+import { ComponentPropsWithoutRef, ComponentType } from 'react';
 
 import { cn } from '@utils/styles';
 
 export const NavbarContainer: ComponentType<
-  DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>
-> = ({ className, children, ...pros }) => {
+  ComponentPropsWithoutRef<'nav'>
+> = ({ className, children, ...props }) => {
   return (
     <nav
       className={cn(
         'bg-atmos-700 dark:bg-fuselage-800 flex w-full items-center justify-between px-4 py-3',
         className,
       )}
-      {...pros}
+      {...props}
     >
       {children}
     </nav>

--- a/components/react/src/components/molecules/navbar/index.tsx
+++ b/components/react/src/components/molecules/navbar/index.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, PropsWithChildren, ReactNode } from 'react';
+import { ComponentPropsWithoutRef, ComponentType, ReactNode } from 'react';
 
 import { NavbarContainer } from '@components/atoms/navbar';
 
@@ -6,20 +6,24 @@ import { cn } from '@utils/styles';
 
 import { IVAOLogo } from 'src/main';
 
-interface NavbarProps {
+interface NavbarProps extends Omit<
+  ComponentPropsWithoutRef<typeof NavbarContainer>,
+  'title'
+> {
   title: ReactNode;
   logoVariant?: 'icon-only';
   diagonalDivider?: boolean;
 }
 
-export const Navbar: ComponentType<PropsWithChildren<NavbarProps>> = ({
+export const Navbar: ComponentType<NavbarProps> = ({
   title,
   children,
   logoVariant,
   diagonalDivider = false,
+  ...props
 }) => {
   return (
-    <NavbarContainer>
+    <NavbarContainer {...props}>
       <div className={'flex items-center gap-3'}>
         {logoVariant === 'icon-only' ? (
           <IVAOLogo color={'white'} onlyIcon />


### PR DESCRIPTION
### Summary
- Refactored index.tsx to use `ComponentPropsWithoutRef<'nav'>` for `NavbarContainer`
- Simplified `NavbarContainer` prop typing and native `<nav>` prop forwarding
- Updated index.tsx so `NavbarProps` extends `NavbarContainer` props and forwards `...props` into the outer container
- Fixes `Button` children inside `Navbar` by preserving native nav props and proper prop forwarding


