### PR TITLE
fix(datatable): ui improvements

### DIFF
--- a/.changeset/fast-doors-raise.md
+++ b/.changeset/fast-doors-raise.md
@@ -1,0 +1,6 @@
+---
+"@ivao/atmosphere-react": minor
+---
+
+data-table: unrestrict view options dropdown width
+  

--- a/.changeset/grumpy-seas-hug.md
+++ b/.changeset/grumpy-seas-hug.md
@@ -1,0 +1,6 @@
+---
+"@ivao/atmosphere-react": minor
+---
+
+Improved UI/UX on DataTable component
+  

--- a/.changeset/grumpy-seas-hug.md
+++ b/.changeset/grumpy-seas-hug.md
@@ -1,6 +1,0 @@
----
-"@ivao/atmosphere-react": minor
----
-
-Improved UI/UX on DataTable component
-  

--- a/.changeset/sweet-suns-guess.md
+++ b/.changeset/sweet-suns-guess.md
@@ -1,0 +1,6 @@
+---
+"@ivao/atmosphere-react": minor
+---
+
+data-table: add option to hide selected row count
+  

--- a/components/react/src/components/molecules/data-table/DataTable.tsx
+++ b/components/react/src/components/molecules/data-table/DataTable.tsx
@@ -43,6 +43,11 @@ export interface DataTableProps<TData>
    * @default 'No results.'
    */
   noResultsMessage?: string;
+  /**
+   * If true, will hide the number of selected rows in the table footer.
+   * @default false
+   */
+  selectedRowsFooterText?: boolean;
 }
 
 export const DataTable = <TData,>({
@@ -52,14 +57,15 @@ export const DataTable = <TData,>({
   ToolbarContent,
   isLoading,
   noResultsMessage,
+  selectedRowsFooterText = false,
   ...props
 }: DataTableProps<TData>) => {
   const table = useReactTable({
     getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
     // Default models for client side data. Not needed for server side data.
     ...(isClientSideData && {
       getPaginationRowModel: getPaginationRowModel(),
-      getSortedRowModel: getSortedRowModel(),
       getFilteredRowModel: getFilteredRowModel(),
     }),
     ...props,
@@ -136,7 +142,12 @@ export const DataTable = <TData,>({
           </TableBody>
         </TableRoot>
       </div>
-      {displayPagination && <DataTablePagination table={table} />}
+      {displayPagination && (
+        <DataTablePagination
+          table={table}
+          selectedRowsFooterText={selectedRowsFooterText}
+        />
+      )}
     </div>
   );
 };

--- a/components/react/src/components/molecules/data-table/DataTable.tsx
+++ b/components/react/src/components/molecules/data-table/DataTable.tsx
@@ -45,9 +45,9 @@ export interface DataTableProps<TData>
   noResultsMessage?: string;
   /**
    * If true, will hide the number of selected rows in the table footer.
-   * @default false
+   * @default true
    */
-  selectedRowsFooterText?: boolean;
+  hideSelectedRowsCount?: boolean;
 }
 
 export const DataTable = <TData,>({
@@ -57,7 +57,7 @@ export const DataTable = <TData,>({
   ToolbarContent,
   isLoading,
   noResultsMessage,
-  selectedRowsFooterText = false,
+  hideSelectedRowsCount = true,
   ...props
 }: DataTableProps<TData>) => {
   const table = useReactTable({
@@ -145,7 +145,7 @@ export const DataTable = <TData,>({
       {displayPagination && (
         <DataTablePagination
           table={table}
-          selectedRowsFooterText={selectedRowsFooterText}
+          hideSelectedRowsCount={hideSelectedRowsCount}
         />
       )}
     </div>

--- a/components/react/src/components/molecules/data-table/DataTablePagination.tsx
+++ b/components/react/src/components/molecules/data-table/DataTablePagination.tsx
@@ -17,21 +17,22 @@ import {
 
 export interface DataTablePaginationProps<TData> {
   table: Table<TData>;
-  selectedRowsFooterText?: boolean;
+  hideSelectedRowsCount: boolean;
 }
 
 export const DataTablePagination = <TData,>({
   table,
-  selectedRowsFooterText = false,
+  hideSelectedRowsCount,
 }: DataTablePaginationProps<TData>) => {
   return (
     <div className={'flex items-center px-2'}>
-      {selectedRowsFooterText && (
-        <div className={'flex-1 text-sm text-muted-foreground'}>
-          {table.getFilteredSelectedRowModel().rows.length} of{' '}
-          {table.getFilteredRowModel().rows.length} row(s) selected.
-        </div>
-      )}
+      {table.getFilteredSelectedRowModel().rows.length > 0 &&
+        !hideSelectedRowsCount && (
+          <div className={'flex-1 text-sm text-muted-foreground'}>
+            {table.getFilteredSelectedRowModel().rows.length} of{' '}
+            {table.getFilteredRowModel().rows.length} row(s) selected.
+          </div>
+        )}
       <div className={'ml-auto flex items-center gap-6 lg:gap-8'}>
         <div className={'flex items-center gap-2'}>
           <p className="text-sm font-medium">Rows per page</p>

--- a/components/react/src/components/molecules/data-table/DataTablePagination.tsx
+++ b/components/react/src/components/molecules/data-table/DataTablePagination.tsx
@@ -28,7 +28,7 @@ export const DataTablePagination = <TData,>({
     <div className={'flex items-center px-2'}>
       {table.getFilteredSelectedRowModel().rows.length > 0 &&
         !hideSelectedRowsCount && (
-          <div className={'flex-1 text-sm text-muted-foreground'}>
+          <div className={'text-muted-foreground flex-1 text-sm'}>
             {table.getFilteredSelectedRowModel().rows.length} of{' '}
             {table.getFilteredRowModel().rows.length} row(s) selected.
           </div>

--- a/components/react/src/components/molecules/data-table/DataTablePagination.tsx
+++ b/components/react/src/components/molecules/data-table/DataTablePagination.tsx
@@ -17,18 +17,22 @@ import {
 
 export interface DataTablePaginationProps<TData> {
   table: Table<TData>;
+  selectedRowsFooterText?: boolean;
 }
 
 export const DataTablePagination = <TData,>({
   table,
+  selectedRowsFooterText = false,
 }: DataTablePaginationProps<TData>) => {
   return (
-    <div className={'flex items-center justify-between px-2'}>
-      <div className={'text-muted-foreground flex-1 text-sm'}>
-        {table.getFilteredSelectedRowModel().rows.length} of{' '}
-        {table.getFilteredRowModel().rows.length} row(s) selected.
-      </div>
-      <div className={'flex items-center gap-6 lg:gap-8'}>
+    <div className={'flex items-center px-2'}>
+      {selectedRowsFooterText && (
+        <div className={'flex-1 text-sm text-muted-foreground'}>
+          {table.getFilteredSelectedRowModel().rows.length} of{' '}
+          {table.getFilteredRowModel().rows.length} row(s) selected.
+        </div>
+      )}
+      <div className={'ml-auto flex items-center gap-6 lg:gap-8'}>
         <div className={'flex items-center gap-2'}>
           <p className="text-sm font-medium">Rows per page</p>
           <SelectRoot

--- a/components/react/src/components/molecules/data-table/DataTableViewOptions.tsx
+++ b/components/react/src/components/molecules/data-table/DataTableViewOptions.tsx
@@ -43,7 +43,7 @@ export function DataTableViewOptions<TData>({
           View
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-[150px]">
+      <DropdownMenuContent align="end" className="min-w-[150px]">
         <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {hideableColumns.map((column) => {

--- a/components/react/src/stories/components/DataTable.stories.tsx
+++ b/components/react/src/stories/components/DataTable.stories.tsx
@@ -427,7 +427,7 @@ const meta = {
     data,
     // Open issue: https://github.com/TanStack/table/issues/4382
     columns: columns as ColumnDef<unknown>[],
-    isClientSideData: true,
+    isClientSideData: false,
     ToolbarContent: ({ table }) => (
       <Input
         placeholder="Filter tasks..."
@@ -473,6 +473,13 @@ const meta = {
       table: {
         defaultValue: {
           summary: 'No results.',
+        },
+      },
+    },
+    selectedRowsFooterText: {
+      table: {
+        defaultValue: {
+          summary: 'false',
         },
       },
     },

--- a/components/react/src/stories/components/DataTable.stories.tsx
+++ b/components/react/src/stories/components/DataTable.stories.tsx
@@ -427,7 +427,7 @@ const meta = {
     data,
     // Open issue: https://github.com/TanStack/table/issues/4382
     columns: columns as ColumnDef<unknown>[],
-    isClientSideData: false,
+    isClientSideData: true,
     ToolbarContent: ({ table }) => (
       <Input
         placeholder="Filter tasks..."
@@ -476,10 +476,10 @@ const meta = {
         },
       },
     },
-    selectedRowsFooterText: {
+    hideSelectedRowsCount: {
       table: {
         defaultValue: {
-          summary: 'false',
+          summary: 'true',
         },
       },
     },


### PR DESCRIPTION
- Added `selectedRowsFooterText` prop to show/hide the number of rows selected in the table footer
- The width of the View menu content was fixed at 150px, causing that words longer than that won't be seen