### PR TITLE
sidebar: add `overflow-y-auto` to scrollable content area

### DIFF
--- a/.changeset/thick-jobs-talk.md
+++ b/.changeset/thick-jobs-talk.md
@@ -1,0 +1,6 @@
+---
+"@ivao/atmosphere-react": patch
+---
+
+sidebar: make overflowing content accesible
+  

--- a/components/react/src/components/atoms/sidebar/SidebarContainer.tsx
+++ b/components/react/src/components/atoms/sidebar/SidebarContainer.tsx
@@ -11,7 +11,7 @@ export const SidebarContainer: ComponentType<PropsWithChildren> = ({
         'border-fuselage-200 bg-fuselage-50 dark:border-fuselage-700 dark:bg-fuselage-900 flex h-full flex-col justify-between border-r'
       }
     >
-      <div className="flex flex-col items-start gap-4 px-4 py-5">
+      <div className="flex flex-col items-start gap-4 overflow-y-auto px-4 py-5">
         {children}
       </div>
       <SidebarCollapseButton />


### PR DESCRIPTION
closes #121

- adds `overflow-y-auto` to the scrollable div in the `SidebarContainer`