### PR TITLE
data-table: apply `meta.className` to table cells

### DIFF
--- a/.changeset/witty-wings-bake.md
+++ b/.changeset/witty-wings-bake.md
@@ -1,0 +1,6 @@
+---
+"@ivao/atmosphere-react": patch
+---
+
+data-table: apply meta-className to table cells
+  

--- a/components/react/src/components/molecules/data-table/DataTable.tsx
+++ b/components/react/src/components/molecules/data-table/DataTable.tsx
@@ -111,7 +111,10 @@ export const DataTable = <TData,>({
                   data-state={row.getIsSelected() && 'selected'}
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
+                    <TableCell
+                      key={cell.id}
+                      className={cell.column.columnDef.meta?.className}
+                    >
                       {flexRender(
                         cell.column.columnDef.cell,
                         cell.getContext(),

--- a/components/react/src/tanstack-table.d.ts
+++ b/components/react/src/tanstack-table.d.ts
@@ -1,0 +1,8 @@
+import '@tanstack/react-table';
+
+declare module '@tanstack/react-table' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    className?: string;
+  }
+}


### PR DESCRIPTION
closes #129

- Reads `meta.className` from `column.columnDef.meta` in `DataTable`
- Applies the className to each `TableCell` during row rendering
- Falls back to no extra classes when `meta.className` is absent