### PR TITLE
data-table: use `meta.name` instead of `column.id` in view options

### DIFF
--- a/.changeset/hot-emus-laugh.md
+++ b/.changeset/hot-emus-laugh.md
@@ -1,0 +1,6 @@
+---
+"@ivao/atmosphere-react": patch
+---
+
+data-table: display meta.name in view options
+  

--- a/components/react/src/components/molecules/data-table/DataTableViewOptions.tsx
+++ b/components/react/src/components/molecules/data-table/DataTableViewOptions.tsx
@@ -54,7 +54,7 @@ export function DataTableViewOptions<TData>({
               checked={column.getIsVisible()}
               onCheckedChange={(value) => column.toggleVisibility(!!value)}
             >
-              {column.id}
+              {column.columnDef.meta?.name ?? column.id}
             </DropdownMenuCheckboxItem>
           );
         })}

--- a/components/react/src/tanstack-table.d.ts
+++ b/components/react/src/tanstack-table.d.ts
@@ -4,5 +4,6 @@ declare module '@tanstack/react-table' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
     className?: string;
+    name?: string;
   }
 }


### PR DESCRIPTION
closes #130

- Reads `meta.name` from `column.columnDef.meta` in `DataTableViewOptions`
- Displays custom human-readable names in the "Toggle columns" dropdown
- Falls back to `column.id` when `meta.name` is not provided (backward compatible)