### PR TITLE
feat(toast): add new color variants

### DIFF
--- a/.changeset/quick-glasses-shout.md
+++ b/.changeset/quick-glasses-shout.md
@@ -1,0 +1,6 @@
+---
+"@ivao/atmosphere-react": minor
+---
+
+toast: add 3 new color variants
+  

--- a/components/react/src/components/atoms/toast/ToastAction.tsx
+++ b/components/react/src/components/atoms/toast/ToastAction.tsx
@@ -12,7 +12,7 @@ export const ToastAction = forwardRef<
     asChild={asChild}
     {...props}
     className={cn(
-      'border-fuselage-200 hover:bg-fuselage-100 focus:ring-ring group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors focus:ring-1 focus:outline-hidden disabled:pointer-events-none disabled:opacity-50',
+      'border-fuselage-200 hover:bg-fuselage-100 focus:ring-ring group-[.success]:hover:bg-semantic-green-400/70 group-[.success]:hover:text-fuselage-700 group-[.success]:focus:ring-semantic-green-500 group-[.error]:border-semantic-red-200/70 group-[.error]:hover:border-semantic-red-200 group-[.error]:hover:bg-semantic-red-200 group-[.error]:hover:text-fuselage-700 group-[.error]:focus:ring-semantic-red-500 group-[.warning]:border-semantic-yellow-500/40 group-[.warning]:hover:border-semantic-yellow-200/80 group-[.warning]:hover:bg-semantic-yellow-200/80 group-[.warning]:hover:text-semantic-yellow-900 group-[.warning]:focus:ring-semantic-yellow-500 inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors group-[.success]:border-green-400/60 focus:ring-1 focus:outline-none disabled:pointer-events-none disabled:opacity-50',
       className,
     )}
     ref={ref}

--- a/components/react/src/components/atoms/toast/ToastRoot.tsx
+++ b/components/react/src/components/atoms/toast/ToastRoot.tsx
@@ -12,18 +12,7 @@ export const ToastRoot = forwardRef<
   ComponentPropsWithoutRef<typeof Root> & VariantProps<typeof toastVariants>
 >(({ className, variant, ...props }, ref) => (
   <Root
-    className={cn(
-      // 'relative rounded-md p-3 flex flex-col xs:flex-row items-stretch xs:items-center justify-between gap-6 shadow-xs',
-      // 'radix-state-open:animate-toast-slide-in-bottom md:radix-state-open:animate-toast-slide-in-right',
-      // 'radix-state-closed:animate-toast-hide',
-      // 'radix-swipe-direction-right:radix-swipe-end:animate-toast-swipe-out-x',
-      // 'radix-swipe-direction-right:translate-x-radix-toast-swipe-move-x',
-      // 'radix-swipe-direction-down:radix-swipe-end:animate-toast-swipe-out-y',
-      // 'radix-swipe-direction-down:translate-y-radix-toast-swipe-move-y',
-      // 'radix-swipe-cancel:translate-x-0 radix-swipe-cancel:duration-200 radix-swipe-cancel:ease-[ease]',
-      toastVariants({ variant }),
-      className,
-    )}
+    className={cn(toastVariants({ variant }), className)}
     {...props}
     ref={ref}
   />

--- a/components/react/src/components/atoms/toast/toastVariants.ts
+++ b/components/react/src/components/atoms/toast/toastVariants.ts
@@ -5,9 +5,13 @@ export const toastVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-background text-foreground border',
-        destructive:
-          'group border-destructive bg-destructive text-destructive-foreground',
+        default: 'default bg-background text-foreground border',
+        success:
+          'success border-semantic-green-200 bg-semantic-green-50 text-semantic-green-900',
+        error:
+          'error border-semantic-red-100 bg-semantic-red-50 text-semantic-red-900',
+        warning:
+          'warning border-semantic-yellow-100 bg-semantic-yellow-50 text-semantic-yellow-900',
       },
     },
     defaultVariants: {

--- a/components/react/src/components/molecules/toast/index.tsx
+++ b/components/react/src/components/molecules/toast/index.tsx
@@ -1,5 +1,7 @@
 import { ComponentProps, ComponentType, ReactNode } from 'react';
 
+import { VariantProps } from 'class-variance-authority';
+
 import {
   ToastAction,
   ToastClose,
@@ -7,11 +9,15 @@ import {
   ToastRoot,
   ToastTitle,
 } from '@components/atoms/toast';
+import { toastVariants } from '@components/atoms/toast/toastVariants';
+
+type ToastVariant = NonNullable<VariantProps<typeof toastVariants>['variant']>;
 
 export type ToastProps = {
   title: string;
   description?: string;
   duration?: number;
+  variant?: ToastVariant;
   toastProps?: ComponentProps<typeof ToastRoot>;
 } & (
   | {
@@ -28,11 +34,12 @@ export const Toast: ComponentType<ToastProps> = ({
   title,
   description,
   duration = 5000,
+  variant = 'default',
   toastProps,
   actionAltText,
   action,
 }) => (
-  <ToastRoot duration={duration} {...toastProps}>
+  <ToastRoot duration={duration} variant={variant} {...toastProps}>
     <div className={'grid gap-1'}>
       <ToastTitle>{title}</ToastTitle>
       {description && <ToastDescription>{description}</ToastDescription>}

--- a/components/react/src/stories/components/Toast.stories.tsx
+++ b/components/react/src/stories/components/Toast.stories.tsx
@@ -25,11 +25,11 @@ const meta = {
   },
   argTypes: {
     title: {
-      description: 'Title of the Toast.',
+      description: 'Title of the toast.',
       type: 'string',
     },
     description: {
-      description: 'Description of the Toast.',
+      description: 'Description of the toast.',
       type: 'string',
     },
     action: {
@@ -52,6 +52,19 @@ const meta = {
       table: {
         type: {
           summary: 'number',
+        },
+      },
+    },
+    variant: {
+      description: 'Color variant of the toast.',
+      control: 'select',
+      options: ['default', 'success', 'error', 'warning'],
+      table: {
+        type: {
+          summary: 'default | success | error | warning',
+        },
+        defaultValue: {
+          summary: 'default',
         },
       },
     },


### PR DESCRIPTION
Added 3 new color variants to the toast component:

- Success
<img width="421" height="109" alt="image" src="https://github.com/user-attachments/assets/cf824051-615c-4041-a7c7-2d8dc5535fbc" />
<img width="407" height="96" alt="image" src="https://github.com/user-attachments/assets/8aad41f4-8ad5-4477-934f-934ed7d9fe25" />

- Error (replaces destructive)
<img width="416" height="102" alt="image" src="https://github.com/user-attachments/assets/3df9ef9f-c31e-45d2-919b-46d0ea94e8d1" />
<img width="420" height="96" alt="image" src="https://github.com/user-attachments/assets/69d43acc-ca47-4d88-8e3e-09eb367cdb50" />

- Warning
<img width="412" height="91" alt="image" src="https://github.com/user-attachments/assets/0176e9f7-9183-4e25-b025-8df291dc3eac" />
<img width="427" height="106" alt="image" src="https://github.com/user-attachments/assets/fb2f9973-eff4-431a-b1b4-e1e644e493b4" />
